### PR TITLE
Client Exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,18 @@ sg.config.access_token_secret = '54321'
 * **access_token_secret**
 * **response_type** - None, 'json', 'pson', 'xml', 'debug'. If None, the response is returned as a python dictionary.
 
+## Exceptions
+
+This API can throw two types of exceptions: ImproperlyConfigured and ClientError
+
+### ImproperlyConfigured
+
+Thrown when authentication is improperly configured or the API version specified is invalid.
+
+### ClientError
+
+Thrown when the server rejects a given request. A ClientError is thrown along with the response message.
+
 ## Filters
 
 Filters are currently untested. 

--- a/surveygizmo/surveygizmo.py
+++ b/surveygizmo/surveygizmo.py
@@ -8,6 +8,10 @@ class ImproperlyConfigured(Exception):
     """ SurveyGizmo is somehow improperly configured."""
     pass
 
+class ClientError(Exception):
+    """ SurveyGizmo responded with failure!"""
+    pass
+
 
 class InvalidFilter(Exception):
     """ Filter format is invalid."""
@@ -255,6 +259,8 @@ class _API(object):
             response = requests.get(url, params=params, **config.requests_kwargs)
 
         response.raise_for_status()
+        if not response.json()['result_ok'] == 1:
+            raise ClientError(response.json()['message'])
 
         if not config.response_type:
             return response.json()


### PR DESCRIPTION
Added functionality to throw a `ClientError` exception when the server returns an error. The `ClientError` exception is triggered when `result_ok` is false and is thrown along with the response `message`
